### PR TITLE
chore: add Claude project skills and hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file=$(jq -r '.tool_input.file_path // empty'); case \"$file\" in *.ts|*.tsx) cd /Users/alexares/dev/personal/daily-track && npx tsc --noEmit 2>&1 | head -20 ;; esac",
+            "async": true,
+            "statusMessage": "Type checking..."
+          },
+          {
+            "type": "command",
+            "command": "file=$(jq -r '.tool_input.file_path // empty'); case \"$file\" in *.ts|*.tsx|*.css) cd /Users/alexares/dev/personal/daily-track && npx eslint \"$file\" --max-warnings=0 2>&1 | tail -10 ;; esac",
+            "async": true,
+            "statusMessage": "Linting..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/review-pr.md
+++ b/.claude/skills/review-pr.md
@@ -1,0 +1,18 @@
+# review-pr
+
+Fetch and summarise all open (unresolved) review comments on the current branch's PR.
+
+## Steps
+
+1. Get the current branch: `git branch --show-current`
+2. Find the open PR for this branch: `gh pr view --json number,title,url,state`
+3. If no open PR exists, say so and stop.
+4. Fetch all review comments: `gh api repos/{owner}/{repo}/pulls/{number}/comments`
+5. Fetch review threads to check which are resolved: use GraphQL to get `reviewThreads` with `isResolved` status.
+6. Filter to only unresolved threads.
+7. For each unresolved thread, show:
+   - File and line number
+   - The original comment
+   - Any replies already made
+8. Group by: **needs code change** vs **needs a reply only**.
+9. Ask the user how they want to proceed — address all, pick specific ones, or skip.

--- a/.claude/skills/ship.md
+++ b/.claude/skills/ship.md
@@ -1,0 +1,27 @@
+# ship
+
+Commit, push, and open a PR for the current branch.
+
+## Usage
+`/ship <issue-number>`
+
+## Steps
+
+1. Run `git status` to see what's changed. If nothing to commit, say so and stop.
+2. Run `npm run build` to verify the project builds. If it fails, stop and show the error — do not ship broken code.
+3. Run `npm test` to verify tests pass. If any fail, stop and show the error.
+4. Stage all changes: `git add -A` — but warn if any `.env` files or secrets appear in the diff.
+5. Write a conventional commit message based on the changes:
+   - `feat:` for new features
+   - `fix:` for bug fixes
+   - `chore:` for setup/config/tooling
+   - `test:` for test-only changes
+   - Keep the subject line under 72 chars
+   - Add a body if the change is non-trivial
+   - Always end with: `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>`
+6. Commit and push: `git push -u origin <current-branch>`
+7. Open a PR targeting `dev` using `gh pr create`:
+   - Title: same as commit subject
+   - Body: summary bullets + `Closes #<issue-number>` + test plan checklist
+   - Always `--base dev`
+8. Output the PR URL.

--- a/.claude/skills/start-issue.md
+++ b/.claude/skills/start-issue.md
@@ -1,0 +1,15 @@
+# start-issue
+
+Start work on a GitHub issue: sync with dev, create the right branch.
+
+## Usage
+`/start-issue <issue-number>`
+
+## Steps
+
+1. Check the current git status — if there are uncommitted changes, warn the user and stop.
+2. Fetch the issue title using: `gh issue view <number> --json title,body`
+3. Generate a branch name in the format `feat/<number>-<slug>` where slug is the issue title lowercased, spaces replaced with hyphens, special characters removed, max 40 chars. Use `chore/` prefix for chore issues and `fix/` for bug issues.
+4. Checkout `dev` and pull latest: `git checkout dev && git pull origin dev`
+5. Create and switch to the new branch: `git checkout -b <branch-name>`
+6. Tell the user the branch name and show a one-line summary of the issue so they know what they're working on.

--- a/.claude/skills/sync.md
+++ b/.claude/skills/sync.md
@@ -1,0 +1,13 @@
+# sync
+
+Sync the current branch with the latest dev.
+
+## Steps
+
+1. Check current branch name with `git branch --show-current`. If on `main` or `dev`, warn and stop — don't rebase protected branches.
+2. Stash any uncommitted changes: `git stash` (only if there are changes).
+3. Fetch and pull latest dev: `git fetch origin dev`
+4. Rebase current branch onto dev: `git rebase origin/dev`
+5. If there are stashed changes, pop them: `git stash pop`
+6. If rebase conflicts occur, stop and clearly list the conflicting files. Do not auto-resolve conflicts.
+7. Report the result: how many commits were rebased, and whether the branch is now up to date.


### PR DESCRIPTION
## Summary

Sets up project-level Claude Code configuration so every future issue follows consistent workflows automatically.

### Skills — `.claude/skills/`

| Command | What it does |
|---|---|
| `/start-issue <n>` | Reads issue title, syncs dev, creates `feat/N-slug` branch |
| `/ship <n>` | Runs build + tests, commits, pushes, opens PR → dev with `Closes #n` |
| `/sync` | Rebases current branch onto latest dev, handles stash |
| `/review-pr` | Fetches unresolved PR comments, groups by needs-code-change vs needs-reply |

### Hooks — `.claude/settings.json`

Both run **async** (background, non-blocking) after any `Write` or `Edit`:

| Hook | Trigger | Command |
|---|---|---|
| Type check | `*.ts` / `*.tsx` | `tsc --noEmit` — catches type errors without waiting for CI |
| Lint | `*.ts` / `*.tsx` / `*.css` | `eslint <file>` — inline lint feedback on the changed file |

### Cleanup
- Cleared stale auto-generated permissions from `.claude/settings.local.json`
- `settings.local.json` stays gitignored via existing `*.local` rule

## Test plan
- [x] Both hooks pipe-tested against a real `.ts` file — clean output, correct exit
- [x] `settings.local.json` confirmed gitignored
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)